### PR TITLE
Add daily CVE scanning schedule, restrict Slack notify to scheduled/dispatch

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,13 +4,18 @@ name: CVE Scanning
 #   * node  - ui/ Angular app, auditjs against Sonatype OSS Index
 #   * maven - setup/ Java project, OWASP dependency-check
 #
-# Runs on push to main, same-repo PRs, and manual dispatch. Fork PRs are
-# skipped (see each job's `if`): they receive no repo secrets, so the scanners
-# would fall back to empty/unauthenticated and fail confusingly. This drops the
-# earlier pull_request_target + allow-unsafe-pr-checkout approach and its
-# "pwn request" risk - fork PRs are simply not scanned here.
+# Runs daily, on push to main, same-repo PRs, and manual dispatch. Fork PRs
+# are skipped (see each job's `if`): they receive no repo secrets, so the
+# scanners would fall back to empty/unauthenticated and fail confusingly.
+# This drops the earlier pull_request_target + allow-unsafe-pr-checkout
+# approach and its "pwn request" risk - fork PRs are simply not scanned here.
+# This repo only tracks main, so unlike finos/rune-common et al the schedule
+# lives directly on this workflow rather than behind a separate dispatcher.
 on:
   workflow_dispatch:
+  schedule:
+    # Every morning, 06:00 UTC.
+    - cron: '0 6 * * *'
   push:
     branches: ["main"]
     paths:
@@ -182,10 +187,11 @@ jobs:
   notify:
     name: Notify Slack
     needs: [node, maven]
-    # Non-PR runs only (push to main, manual dispatch); always() so a failed
-    # scan still notifies. Skips quietly when the webhook secret is unset, so a
-    # clean run never goes red just because Slack isn't wired up.
-    if: always() && github.event_name != 'pull_request'
+    # Scheduled or manually-dispatched runs only, so push/PR runs stay quiet;
+    # always() so a failed scan still notifies. Skips quietly when the webhook
+    # secret is unset, so a clean run never goes red just because Slack isn't
+    # wired up.
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Post result to Slack


### PR DESCRIPTION
## Summary
- Adds `schedule: - cron: '0 6 * * *'` (06:00 UTC daily) directly to `cve-scanning.yml`. This repo only tracks `main`, so unlike `finos/rune-common`/`finos/common-domain-model` there's no need for a separate schedule-dispatcher workflow.
- Narrows the `notify` job's Slack condition from "anything but a PR" to scheduled or manually-dispatched runs only, so push-to-main runs no longer post to Slack (the commit's own status check already covers that case).

## Test plan
- [ ] Confirm `workflow_dispatch` still triggers a Slack notification
- [ ] Confirm a push to `main` no longer triggers a Slack notification
- [ ] Confirm the schedule fires at 06:00 UTC once merged