### PR TITLE
CVE scanning: run on weekdays only, at 11:00 UTC

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,8 +4,8 @@ name: CVE Scanning
 #   * node  - ui/ Angular app, auditjs against Sonatype OSS Index
 #   * maven - setup/ Java project, OWASP dependency-check
 #
-# Runs daily, on push to main, same-repo PRs, and manual dispatch. Fork PRs
-# are skipped (see each job's `if`): they receive no repo secrets, so the
+# Runs on weekdays, on push to main, same-repo PRs, and manual dispatch. Fork
+# PRs are skipped (see each job's `if`): they receive no repo secrets, so the
 # scanners would fall back to empty/unauthenticated and fail confusingly.
 # This drops the earlier pull_request_target + allow-unsafe-pr-checkout
 # approach and its "pwn request" risk - fork PRs are simply not scanned here.
@@ -14,8 +14,10 @@ name: CVE Scanning
 on:
   workflow_dispatch:
   schedule:
-    # Every morning, 06:00 UTC.
-    - cron: '0 6 * * *'
+    # Run on weekdays only (CVEs published over the weekend are still caught
+    # by Monday's run), at 11:00 UTC - a slot free of the rosetta-models
+    # repos' staggered start times (05:00-10:30 in 30-minute steps).
+    - cron: '0 11 * * 1-5'
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
## Summary
- Restrict the CVE scanning schedule to weekdays (CVEs published over the weekend are still caught by Monday's run)
- Move the start time from 06:00 to 11:00 UTC, clear of every rosetta-models repo's staggered start time (05:00-10:30 in 30-minute steps) — the old 06:00 slot collided with rosetta-models/bdt-as-rune

## Test plan
- [x] `cron: '0 11 * * 1-5'` validated against crontab syntax
- No functional test needed — schedule-only change to a workflow that already runs correctly on `workflow_dispatch`